### PR TITLE
Faster equality

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -238,7 +238,11 @@ func (f Decimal) Equal(f0 Decimal) bool {
 	if f.IsNaN() || f0.IsNaN() {
 		return false
 	}
-	return f.Cmp(f0) == 0
+
+	if f.fp == f0.fp {
+		return true
+	}
+	return false
 }
 
 // GreaterThan tests Cmp() for 1

--- a/decimal_bench_test.go
+++ b/decimal_bench_test.go
@@ -189,3 +189,14 @@ func BenchmarkWriteTo(b *testing.B) {
 		f0.WriteTo(buf)
 	}
 }
+
+var res bool
+
+func BenchmarkEqualDecimal(b *testing.B) {
+	f0 := NewF(1)
+	f1 := NewF(1)
+
+	for i := 0; i < b.N; i++ {
+		res = f1.Equal(f0)
+	}
+}


### PR DESCRIPTION
```
BenchmarkEqualDecimal-8   	1000000000	         0.3732 ns/op
```

vs

```
BenchmarkEqualDecimal-8   	520845020	         2.331 ns/op
```