### PR TITLE
remove nan

### DIFF
--- a/decimal_bench_test.go
+++ b/decimal_bench_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func BenchmarkAddDecimal(b *testing.B) {
-	f0 := NewF(1)
-	f1 := NewF(1)
+	f0 := MustParseFloat(1)
+	f1 := MustParseFloat(1)
 
 	for i := 0; i < b.N; i++ {
 		f1 = f1.Add(f0)
@@ -42,8 +42,8 @@ func BenchmarkAddBigFloat(b *testing.B) {
 }
 
 func BenchmarkMulDecimal(b *testing.B) {
-	f0 := NewF(123456789.0)
-	f1 := NewF(1234.0)
+	f0 := MustParseFloat(123456789.0)
+	f1 := MustParseFloat(1234.0)
 
 	for i := 0; i < b.N; i++ {
 		f0.Mul(f1)
@@ -77,8 +77,8 @@ func BenchmarkMulBigFloat(b *testing.B) {
 }
 
 func BenchmarkDivDecimal(b *testing.B) {
-	f0 := NewF(123456789.0)
-	f1 := NewF(1234.0)
+	f0 := MustParseFloat(123456789.0)
+	f1 := MustParseFloat(1234.0)
 
 	for i := 0; i < b.N; i++ {
 		f0.Div(f1)
@@ -112,8 +112,8 @@ func BenchmarkDivBigFloat(b *testing.B) {
 }
 
 func BenchmarkCmpDecimal(b *testing.B) {
-	f0 := NewF(123456789.0)
-	f1 := NewF(1234.0)
+	f0 := MustParseFloat(123456789.0)
+	f1 := MustParseFloat(1234.0)
 
 	for i := 0; i < b.N; i++ {
 		f0.Cmp(f1)
@@ -145,14 +145,14 @@ func BenchmarkCmpBigFloat(b *testing.B) {
 }
 
 func BenchmarkStringDecimal(b *testing.B) {
-	f0 := NewF(123456789.12345)
+	f0 := MustParseFloat(123456789.12345)
 
 	for i := 0; i < b.N; i++ {
 		f0.String()
 	}
 }
 func BenchmarkStringNDecimal(b *testing.B) {
-	f0 := NewF(123456789.12345)
+	f0 := MustParseFloat(123456789.12345)
 
 	for i := 0; i < b.N; i++ {
 		f0.StringN(5)
@@ -181,7 +181,7 @@ func BenchmarkStringBigFloat(b *testing.B) {
 }
 
 func BenchmarkWriteTo(b *testing.B) {
-	f0 := NewF(123456789.0)
+	f0 := MustParseFloat(123456789.0)
 
 	buf := new(bytes.Buffer)
 
@@ -193,8 +193,8 @@ func BenchmarkWriteTo(b *testing.B) {
 var res bool
 
 func BenchmarkEqualDecimal(b *testing.B) {
-	f0 := NewF(1)
-	f1 := NewF(1)
+	f0 := MustParseFloat(1)
+	f1 := MustParseFloat(1)
 
 	for i := 0; i < b.N; i++ {
 		res = f1.Equal(f0)
@@ -202,8 +202,8 @@ func BenchmarkEqualDecimal(b *testing.B) {
 }
 
 func BenchmarkLessThanDecimal(b *testing.B) {
-	f0 := NewF(1)
-	f1 := NewF(1)
+	f0 := MustParseFloat(1)
+	f1 := MustParseFloat(1)
 
 	for i := 0; i < b.N; i++ {
 		res = f1.LessThan(f0)
@@ -211,8 +211,8 @@ func BenchmarkLessThanDecimal(b *testing.B) {
 }
 
 func BenchmarkLessThanOrEqualDecimal(b *testing.B) {
-	f0 := NewF(1)
-	f1 := NewF(1)
+	f0 := MustParseFloat(1)
+	f1 := MustParseFloat(1)
 
 	for i := 0; i < b.N; i++ {
 		res = f1.LessThanOrEqual(f0)
@@ -220,8 +220,8 @@ func BenchmarkLessThanOrEqualDecimal(b *testing.B) {
 }
 
 func BenchmarkGreaterThanDecimal(b *testing.B) {
-	f0 := NewF(1)
-	f1 := NewF(1)
+	f0 := MustParseFloat(1)
+	f1 := MustParseFloat(1)
 
 	for i := 0; i < b.N; i++ {
 		res = f1.GreaterThan(f0)
@@ -229,8 +229,8 @@ func BenchmarkGreaterThanDecimal(b *testing.B) {
 }
 
 func BenchmarkGreaterThanOrEqualDecimal(b *testing.B) {
-	f0 := NewF(1)
-	f1 := NewF(1)
+	f0 := MustParseFloat(1)
+	f1 := MustParseFloat(1)
 
 	for i := 0; i < b.N; i++ {
 		res = f1.GreaterThanOrEqual(f0)

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -6,111 +6,79 @@ import (
 	"testing"
 
 	. "github.com/geseq/udecimal"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBasic(t *testing.T) {
 	f0 := MustParse("123.456")
 	f1 := MustParse("123.456")
 
-	if !f0.Equal(f1) {
-		t.Error("should be equal", f0, f1)
-	}
-
-	if f0.Int() != 123 {
-		t.Error("should be equal", f0.Int(), 123)
-	}
-
-	if f0.String() != "123.456" {
-		t.Error("should be equal", f0.String(), "123.456")
-	}
+	assert.Equal(t, f0, f1)
+	assert.True(t, f0.Equal(f1))
+	assert.True(t, f1.Equal(f0))
+	assert.Equal(t, uint64(123), f0.Int())
+	assert.Equal(t, uint64(123), f1.Int())
+	assert.Equal(t, "123.456", f0.String())
+	assert.Equal(t, "123.456", f1.String())
 
 	f0 = MustParseFloat(1)
 	f1 = MustParseFloat(.5).Add(MustParseFloat(.5))
 	f2 := MustParseFloat(.3).Add(MustParseFloat(.3)).Add(MustParseFloat(.4))
 
-	if !f0.Equal(f1) {
-		t.Error("should be equal", f0, f1)
-	}
-	if !f0.Equal(f2) {
-		t.Error("should be equal", f0, f2)
-	}
+	assert.True(t, f0.Equal(f1))
+	assert.True(t, f0.Equal(f2))
 
 	f0 = MustParseFloat(.999)
-	if f0.String() != "0.999" {
-		t.Error("should be equal", f0, "0.999")
-	}
+	assert.Equal(t, "0.999", f0.String())
 }
 
 func TestEqual(t *testing.T) {
 	f0 := Zero
 	f1 := MustParse("123.456")
-	if f0.Equal(f1) {
-		t.Error("should not be equal", f0, f1)
-	}
-
-	if f1.Equal(f0) {
-		t.Error("should not be equal", f0, f1)
-	}
+	assert.NotEqual(t, f0, f1)
+	assert.False(t, f0.Equal(f1))
+	assert.False(t, f1.Equal(f0))
 
 	f1 = Zero
-	if f0.Equal(f1) {
-		t.Error("should not be equal", f0, f1)
-	}
+	assert.True(t, f0.Equal(f1))
 
 	f0 = Zero
-	if !f0.Equal(f1) {
-		t.Error("should be equal", f0, f1)
-	}
-
-	if f0.Int() != 0 {
-		t.Error("should be equal", f0.Int(), 0)
-	}
+	assert.True(t, f0.Equal(f1))
+	assert.Equal(t, uint64(0), f0.Int())
 }
 
 func TestNew(t *testing.T) {
 	f := New(123, 1)
-	if f.String() != "1230" {
-		t.Error("should be equal", f, "1230")
-	}
-	f = New(123, 0)
-	if f.String() != "123" {
-		t.Error("should be equal", f, "123")
-	}
-	f = New(123456789012, 9)
-	if f.String() != "NaN" {
-		t.Error("should be equal", f, "NaN")
-	}
-	f = New(123, -1)
-	if f.String() != "12.3" {
-		t.Error("should be equal", f, "12.3")
-	}
-	f = New(123456789001, -9)
-	if f.String() != "123.456789" {
-		t.Error("should be equal", f, "123.456789")
-	}
-	f = New(123456789012, -9)
-	if f.StringN(7) != "123.4567890" {
-		t.Error("should be equal", f.StringN(7), "123.4567890")
-	}
-	f = New(123456789012, -9)
-	if f.StringN(8) != "123.45678901" {
-		t.Error("should be equal", f.StringN(8), "123.45678901")
-	}
+	assert.Equal(t, "1230", f.String())
 
+	f = New(123, 0)
+	assert.Equal(t, "123", f.String())
+
+	//	f = New(123456789012, 9)
+	//	assert.Equal(t, "123", f.String())
+
+	f = New(123, -1)
+	assert.Equal(t, "12.3", f.String())
+
+	f = New(123456789001, -9)
+	assert.Equal(t, "123.456789", f.String())
+
+	f = New(123456789012, -9)
+	assert.Equal(t, "123.4567890", f.StringN(7))
+
+	f = New(123456789012, -9)
+	assert.Equal(t, "123.45678901", f.StringN(8))
 }
 
 func TestParse(t *testing.T) {
 	_, err := Parse("123")
-	if err != nil {
-		t.Fail()
+	assert.NoError(t, err)
 
-	}
+	_, err = Parse("123,456")
+	assert.Error(t, err)
+
 	_, err = Parse("abc")
-	if err == nil {
-		t.Fail()
-
-	}
-
+	assert.Error(t, err)
 }
 
 func TestMustParse(t *testing.T) {
@@ -121,67 +89,46 @@ func TestMustParse(t *testing.T) {
 		}
 
 	}()
-	_ = MustParse("abc")
 
+	_ = MustParse("abc")
 }
 
 func TestNewI(t *testing.T) {
 	f := NewI(123, 1)
-	if f.String() != "12.3" {
-		t.Error("should be equal", f, "12.3")
-	}
+	assert.Equal(t, "12.3", f.String())
+
 	f = NewI(123, 0)
-	if f.String() != "123" {
-		t.Error("should be equal", f, "123")
-	}
+	assert.Equal(t, "123", f.String())
+
 	f = NewI(123456789001, 9)
-	if f.String() != "123.456789" {
-		t.Error("should be equal", f, "123.456789")
-	}
+	assert.Equal(t, "123.456789", f.String())
+
 	f = NewI(123456789012, 9)
-	if f.StringN(7) != "123.4567890" {
-		t.Error("should be equal", f.StringN(7), "123.4567890")
-	}
+	assert.Equal(t, "123.4567890", f.StringN(7))
+	assert.Equal(t, "123.45678901", f.String())
+
 	f = NewI(123456789012, 9)
-	if f.StringN(8) != "123.45678901" {
-		t.Error("should be equal", f.StringN(8), "123.45678901")
-	}
+	assert.Equal(t, "123.45678901", f.StringN(8))
 }
 
 func TestMaxValue(t *testing.T) {
 	f0 := MustParse("12345678901")
-	if f0.String() != "12345678901" {
-		t.Error("should be equal", f0, "12345678901")
-	}
-	f0 = MustParse("123456789012")
-	if f0.String() != "NaN" {
-		t.Error("should be equal", f0, "NaN")
-	}
-	f0 = MustParse("-12345678901")
-	if f0.String() != "NaN" {
-		t.Error("should be equal", f0, "NaN")
-	}
-	f0 = MustParse("-123456789012")
-	if f0.String() != "NaN" {
-		t.Error("should be equal", f0, "NaN")
-	}
-	f0 = MustParse("99999999999")
-	if f0.String() != "99999999999" {
-		t.Error("should be equal", f0, "99999999999")
-	}
-	f0 = MustParse("9.99999999")
-	if f0.String() != "9.99999999" {
-		t.Error("should be equal", f0, "9.99999999")
-	}
-	f0 = MustParse("99999999999.99999999")
-	if f0.String() != "99999999999.99999999" {
-		t.Error("should be equal", f0, "99999999999.99999999")
-	}
-	f0 = MustParse("99999999999.12345678901234567890")
-	if f0.String() != "99999999999.12345678" {
-		t.Error("should be equal", f0, "99999999999.12345678")
-	}
+	assert.Equal(t, f0.String(), "12345678901")
+	assert.Panics(t, func() { f0 = MustParse("123456789012") })
+	assert.Panics(t, func() { f0 = MustParse("-12345678901") })
+	assert.Panics(t, func() { f0 = MustParse("-123456789012") })
 
+	f0 = MustParse("99999999999")
+	assert.Equal(t, f0.String(), "99999999999")
+
+	f0 = MustParse("9.99999999")
+	assert.Equal(t, f0.String(), "9.99999999")
+
+	f0 = MustParse("99999999999.99999999")
+	assert.Equal(t, f0.String(), "99999999999.99999999")
+
+	f0 = MustParse("99999999999.12345678901234567890")
+	assert.Equal(t, f0.String(), "99999999999.12345678")
 }
 
 func TestFloat(t *testing.T) {
@@ -257,20 +204,6 @@ func TestAddSub(t *testing.T) {
 
 }
 
-func TestAbs(t *testing.T) {
-	f := MustParse("NaN")
-	// TODO Handle panic
-
-	f = MustParse("1")
-	if f.String() != "1" {
-		t.Error("should be equal", f, "1")
-	}
-	f = MustParse("-1")
-	if f.String() != "NaN" {
-		t.Error("should be equal", f, "NaN")
-	}
-}
-
 func TestMulDiv(t *testing.T) {
 	f0 := MustParse("123.456")
 	f1 := MustParse("1000")
@@ -285,38 +218,6 @@ func TestMulDiv(t *testing.T) {
 	f2 = f0.Mul(f1)
 	if f2.String() != "12.3456" {
 		t.Error("should be equal", f2.String(), "12.3456")
-	}
-
-	f0 = MustParse("123.456")
-	f1 = MustParse("-1000")
-
-	f2 = f0.Mul(f1)
-	if f2.String() != "NaN" {
-		t.Error("should be equal", f2.String(), "NaN")
-	}
-
-	f0 = MustParse("-123.456")
-	f1 = MustParse("-1000")
-
-	f2 = f0.Mul(f1)
-	if f2.String() != "NaN" {
-		t.Error("should be equal", f2.String(), "NaN")
-	}
-
-	f0 = MustParse("123.456")
-	f1 = MustParse("-1000")
-
-	f2 = f0.Mul(f1)
-	if f2.String() != "NaN" {
-		t.Error("should be equal", f2.String(), "NaN")
-	}
-
-	f0 = MustParse("-123.456")
-	f1 = MustParse("-1000")
-
-	f2 = f0.Mul(f1)
-	if f2.String() != "NaN" {
-		t.Error("should be equal", f2.String(), "NaN")
 	}
 
 	f0 = MustParse("10000.1")
@@ -367,27 +268,17 @@ func TestMulDiv(t *testing.T) {
 }
 
 func TestNegatives(t *testing.T) {
+	assert.Panics(t, func() { MustParse("-1") })
+
 	f0 := MustParse("99")
 	f1 := MustParse("100")
 
-	f2 := f0.Sub(f1)
-	if f2.String() != "NaN" {
-		t.Error("should be equal", f2.String(), "NaN")
-	}
-	f0 = MustParse("-1")
-	f1 = MustParse("-1")
+	assert.Panics(t, func() { f0.Sub(f1) })
 
-	f2 = f0.Sub(f1)
-	if f2.String() != "NaN" {
-		t.Error("should be equal", f2.String(), "NaN")
-	}
 	f0 = MustParse(".001")
 	f1 = MustParse(".002")
 
-	f2 = f0.Sub(f1)
-	if f2.String() != "NaN" {
-		t.Error("should be equal", f2.String(), "NaN")
-	}
+	assert.Panics(t, func() { f0.Sub(f1) })
 }
 
 func TestOverflow(t *testing.T) {
@@ -410,16 +301,13 @@ func TestOverflow(t *testing.T) {
 }
 
 func TestNaN(t *testing.T) {
-	f0 := MustParseFloat(math.NaN())
-	if f0.String() != "NaN" {
-		t.Error("should be equal", f0.String(), "NaN")
-	}
-	f0 = MustParse("NaN")
-	f0 = MustParse("0.0004096")
+	assert.Panics(t, func() { MustParseFloat(math.NaN()) })
+	assert.Panics(t, func() { MustParse("NaN") })
+
+	f0 := MustParse("0.0004096")
 	if f0.String() != "0.0004096" {
 		t.Error("should be equal", f0.String(), "0.0004096")
 	}
-
 }
 
 func TestIntFrac(t *testing.T) {
@@ -494,18 +382,6 @@ func TestRound(t *testing.T) {
 
 	if f1.String() != "1.1235" {
 		t.Error("should be equal", f1, "1.1235")
-	}
-
-	f0 = MustParse("-1.12345")
-	f1 = f0.Round(3)
-
-	if f1.String() != "NaN" {
-		t.Error("should be equal", f1, "NaN")
-	}
-	f1 = f0.Round(4)
-
-	if f1.String() != "NaN" {
-		t.Error("should be equal", f1, "NaN")
 	}
 }
 

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -2,7 +2,6 @@ package udecimal_test
 
 import (
 	"bytes"
-	"encoding/json"
 	"math"
 	"testing"
 
@@ -10,8 +9,8 @@ import (
 )
 
 func TestBasic(t *testing.T) {
-	f0 := NewS("123.456")
-	f1 := NewS("123.456")
+	f0 := MustParse("123.456")
+	f1 := MustParse("123.456")
 
 	if !f0.Equal(f1) {
 		t.Error("should be equal", f0, f1)
@@ -25,9 +24,9 @@ func TestBasic(t *testing.T) {
 		t.Error("should be equal", f0.String(), "123.456")
 	}
 
-	f0 = NewF(1)
-	f1 = NewF(.5).Add(NewF(.5))
-	f2 := NewF(.3).Add(NewF(.3)).Add(NewF(.4))
+	f0 = MustParseFloat(1)
+	f1 = MustParseFloat(.5).Add(MustParseFloat(.5))
+	f2 := MustParseFloat(.3).Add(MustParseFloat(.3)).Add(MustParseFloat(.4))
 
 	if !f0.Equal(f1) {
 		t.Error("should be equal", f0, f1)
@@ -36,21 +35,15 @@ func TestBasic(t *testing.T) {
 		t.Error("should be equal", f0, f2)
 	}
 
-	f0 = NewF(.999)
+	f0 = MustParseFloat(.999)
 	if f0.String() != "0.999" {
 		t.Error("should be equal", f0, "0.999")
 	}
 }
 
 func TestEqual(t *testing.T) {
-	f0 := NaN
-	f1 := NaN
-
-	if f0.Equal(f1) {
-		t.Error("should not be equal", f0, f1)
-	}
-
-	f1 = NewS("123.456")
+	f0 := Zero
+	f1 := MustParse("123.456")
 	if f0.Equal(f1) {
 		t.Error("should not be equal", f0, f1)
 	}
@@ -61,10 +54,6 @@ func TestEqual(t *testing.T) {
 
 	f1 = Zero
 	if f0.Equal(f1) {
-		t.Error("should not be equal", f0, f1)
-	}
-
-	if f1.Equal(f0) {
 		t.Error("should not be equal", f0, f1)
 	}
 
@@ -160,35 +149,35 @@ func TestNewI(t *testing.T) {
 }
 
 func TestMaxValue(t *testing.T) {
-	f0 := NewS("12345678901")
+	f0 := MustParse("12345678901")
 	if f0.String() != "12345678901" {
 		t.Error("should be equal", f0, "12345678901")
 	}
-	f0 = NewS("123456789012")
+	f0 = MustParse("123456789012")
 	if f0.String() != "NaN" {
 		t.Error("should be equal", f0, "NaN")
 	}
-	f0 = NewS("-12345678901")
+	f0 = MustParse("-12345678901")
 	if f0.String() != "NaN" {
 		t.Error("should be equal", f0, "NaN")
 	}
-	f0 = NewS("-123456789012")
+	f0 = MustParse("-123456789012")
 	if f0.String() != "NaN" {
 		t.Error("should be equal", f0, "NaN")
 	}
-	f0 = NewS("99999999999")
+	f0 = MustParse("99999999999")
 	if f0.String() != "99999999999" {
 		t.Error("should be equal", f0, "99999999999")
 	}
-	f0 = NewS("9.99999999")
+	f0 = MustParse("9.99999999")
 	if f0.String() != "9.99999999" {
 		t.Error("should be equal", f0, "9.99999999")
 	}
-	f0 = NewS("99999999999.99999999")
+	f0 = MustParse("99999999999.99999999")
 	if f0.String() != "99999999999.99999999" {
 		t.Error("should be equal", f0, "99999999999.99999999")
 	}
-	f0 = NewS("99999999999.12345678901234567890")
+	f0 = MustParse("99999999999.12345678901234567890")
 	if f0.String() != "99999999999.12345678" {
 		t.Error("should be equal", f0, "99999999999.12345678")
 	}
@@ -196,45 +185,45 @@ func TestMaxValue(t *testing.T) {
 }
 
 func TestFloat(t *testing.T) {
-	f0 := NewS("123.456")
-	f1 := NewF(123.456)
+	f0 := MustParse("123.456")
+	f1 := MustParseFloat(123.456)
 
 	if !f0.Equal(f1) {
 		t.Error("should be equal", f0, f1)
 	}
 
-	f1 = NewF(0.0001)
+	f1 = MustParseFloat(0.0001)
 
 	if f1.String() != "0.0001" {
 		t.Error("should be equal", f1.String(), "0.0001")
 	}
 
-	f1 = NewS(".1")
-	f2 := NewS(NewF(f1.Float()).String())
+	f1 = MustParse(".1")
+	f2 := MustParse(MustParseFloat(f1.Float()).String())
 	if !f1.Equal(f2) {
 		t.Error("should be equal", f1, f2)
 	}
 }
 
 func TestInfinite(t *testing.T) {
-	f0 := NewS("0.10")
-	f1 := NewF(0.10)
+	f0 := MustParse("0.10")
+	f1 := MustParseFloat(0.10)
 
 	if !f0.Equal(f1) {
 		t.Error("should be equal", f0, f1)
 	}
 
-	f2 := NewF(0.0)
+	f2 := MustParseFloat(0.0)
 	for i := 0; i < 3; i++ {
-		f2 = f2.Add(NewF(.10))
+		f2 = f2.Add(MustParseFloat(.10))
 	}
 	if f2.String() != "0.3" {
 		t.Error("should be equal", f2.String(), "0.3")
 	}
 
-	f2 = NewF(0.0)
+	f2 = MustParseFloat(0.0)
 	for i := 0; i < 10; i++ {
-		f2 = f2.Add(NewF(.10))
+		f2 = f2.Add(MustParseFloat(.10))
 	}
 	if f2.String() != "1" {
 		t.Error("should be equal", f2.String(), "1")
@@ -243,8 +232,8 @@ func TestInfinite(t *testing.T) {
 }
 
 func TestAddSub(t *testing.T) {
-	f0 := NewS("1")
-	f1 := NewS("0.3333333")
+	f0 := MustParse("1")
+	f1 := MustParse("0.3333333")
 
 	f2 := f0.Sub(f1)
 	f2 = f2.Sub(f1)
@@ -253,14 +242,14 @@ func TestAddSub(t *testing.T) {
 	if f2.String() != "0.0000001" {
 		t.Error("should be equal", f2.String(), "0.0000001")
 	}
-	f2 = f2.Sub(NewS("0.0000001"))
+	f2 = f2.Sub(MustParse("0.0000001"))
 	if f2.String() != "0" {
 		t.Error("should be equal", f2.String(), "0")
 	}
 
-	f0 = NewS("0")
+	f0 = MustParse("0")
 	for i := 0; i < 10; i++ {
-		f0 = f0.Add(NewS("0.1"))
+		f0 = f0.Add(MustParse("0.1"))
 	}
 	if f0.String() != "1" {
 		t.Error("should be equal", f0.String(), "1")
@@ -269,70 +258,69 @@ func TestAddSub(t *testing.T) {
 }
 
 func TestAbs(t *testing.T) {
-	f := NewS("NaN")
-	if !f.IsNaN() {
-		t.Error("should be NaN", f)
-	}
-	f = NewS("1")
+	f := MustParse("NaN")
+	// TODO Handle panic
+
+	f = MustParse("1")
 	if f.String() != "1" {
 		t.Error("should be equal", f, "1")
 	}
-	f = NewS("-1")
+	f = MustParse("-1")
 	if f.String() != "NaN" {
 		t.Error("should be equal", f, "NaN")
 	}
 }
 
 func TestMulDiv(t *testing.T) {
-	f0 := NewS("123.456")
-	f1 := NewS("1000")
+	f0 := MustParse("123.456")
+	f1 := MustParse("1000")
 
 	f2 := f0.Mul(f1)
 	if f2.String() != "123456" {
 		t.Error("should be equal", f2.String(), "123456")
 	}
-	f0 = NewS("123456")
-	f1 = NewS("0.0001")
+	f0 = MustParse("123456")
+	f1 = MustParse("0.0001")
 
 	f2 = f0.Mul(f1)
 	if f2.String() != "12.3456" {
 		t.Error("should be equal", f2.String(), "12.3456")
 	}
 
-	f0 = NewS("123.456")
-	f1 = NewS("-1000")
+	f0 = MustParse("123.456")
+	f1 = MustParse("-1000")
 
 	f2 = f0.Mul(f1)
 	if f2.String() != "NaN" {
 		t.Error("should be equal", f2.String(), "NaN")
 	}
 
-	f0 = NewS("-123.456")
-	f1 = NewS("-1000")
+	f0 = MustParse("-123.456")
+	f1 = MustParse("-1000")
 
 	f2 = f0.Mul(f1)
 	if f2.String() != "NaN" {
 		t.Error("should be equal", f2.String(), "NaN")
 	}
 
-	f0 = NewS("123.456")
-	f1 = NewS("-1000")
+	f0 = MustParse("123.456")
+	f1 = MustParse("-1000")
 
 	f2 = f0.Mul(f1)
 	if f2.String() != "NaN" {
 		t.Error("should be equal", f2.String(), "NaN")
 	}
 
-	f0 = NewS("-123.456")
-	f1 = NewS("-1000")
+	f0 = MustParse("-123.456")
+	f1 = MustParse("-1000")
 
 	f2 = f0.Mul(f1)
 	if f2.String() != "NaN" {
 		t.Error("should be equal", f2.String(), "NaN")
 	}
 
-	f0 = NewS("10000.1")
-	f1 = NewS("10000")
+	f0 = MustParse("10000.1")
+	f1 = MustParse("10000")
 
 	f2 = f0.Mul(f1)
 	if f2.String() != "100001000" {
@@ -344,32 +332,32 @@ func TestMulDiv(t *testing.T) {
 		t.Error("should be equal", f0, f2)
 	}
 
-	f0 = NewS("2")
-	f1 = NewS("3")
+	f0 = MustParse("2")
+	f1 = MustParse("3")
 
 	f2 = f0.Div(f1)
 	if f2.String() != "0.66666667" {
 		t.Error("should be equal", f2.String(), "0.66666667")
 	}
 
-	f0 = NewS("1000")
-	f1 = NewS("10")
+	f0 = MustParse("1000")
+	f1 = MustParse("10")
 
 	f2 = f0.Div(f1)
 	if f2.String() != "100" {
 		t.Error("should be equal", f2.String(), "100")
 	}
 
-	f0 = NewS("1000")
-	f1 = NewS("0.1")
+	f0 = MustParse("1000")
+	f1 = MustParse("0.1")
 
 	f2 = f0.Div(f1)
 	if f2.String() != "10000" {
 		t.Error("should be equal", f2.String(), "10000")
 	}
 
-	f0 = NewS("1")
-	f1 = NewS("0.1")
+	f0 = MustParse("1")
+	f1 = MustParse("0.1")
 
 	f2 = f0.Mul(f1)
 	if f2.String() != "0.1" {
@@ -379,22 +367,22 @@ func TestMulDiv(t *testing.T) {
 }
 
 func TestNegatives(t *testing.T) {
-	f0 := NewS("99")
-	f1 := NewS("100")
+	f0 := MustParse("99")
+	f1 := MustParse("100")
 
 	f2 := f0.Sub(f1)
 	if f2.String() != "NaN" {
 		t.Error("should be equal", f2.String(), "NaN")
 	}
-	f0 = NewS("-1")
-	f1 = NewS("-1")
+	f0 = MustParse("-1")
+	f1 = MustParse("-1")
 
 	f2 = f0.Sub(f1)
 	if f2.String() != "NaN" {
 		t.Error("should be equal", f2.String(), "NaN")
 	}
-	f0 = NewS(".001")
-	f1 = NewS(".002")
+	f0 = MustParse(".001")
+	f1 = MustParse(".002")
 
 	f2 = f0.Sub(f1)
 	if f2.String() != "NaN" {
@@ -403,38 +391,31 @@ func TestNegatives(t *testing.T) {
 }
 
 func TestOverflow(t *testing.T) {
-	f0 := NewF(1.12345678)
+	f0 := MustParseFloat(1.12345678)
 	if f0.String() != "1.12345678" {
 		t.Error("should be equal", f0.String(), "1.12345678")
 	}
-	f0 = NewF(1.123456789123)
+	f0 = MustParseFloat(1.123456789123)
 	if f0.String() != "1.12345679" {
 		t.Error("should be equal", f0.String(), "1.12345679")
 	}
-	f0 = NewF(1.0 / 3.0)
+	f0 = MustParseFloat(1.0 / 3.0)
 	if f0.String() != "0.33333333" {
 		t.Error("should be equal", f0.String(), "0.33333333")
 	}
-	f0 = NewF(2.0 / 3.0)
+	f0 = MustParseFloat(2.0 / 3.0)
 	if f0.String() != "0.66666667" {
 		t.Error("should be equal", f0.String(), "0.66666667")
 	}
 }
 
 func TestNaN(t *testing.T) {
-	f0 := NewF(math.NaN())
-	if !f0.IsNaN() {
-		t.Error("f0 should be NaN")
-	}
+	f0 := MustParseFloat(math.NaN())
 	if f0.String() != "NaN" {
 		t.Error("should be equal", f0.String(), "NaN")
 	}
-	f0 = NewS("NaN")
-	if !f0.IsNaN() {
-		t.Error("f0 should be NaN")
-	}
-
-	f0 = NewS("0.0004096")
+	f0 = MustParse("NaN")
+	f0 = MustParse("0.0004096")
 	if f0.String() != "0.0004096" {
 		t.Error("should be equal", f0.String(), "0.0004096")
 	}
@@ -442,7 +423,7 @@ func TestNaN(t *testing.T) {
 }
 
 func TestIntFrac(t *testing.T) {
-	f0 := NewF(1234.5678)
+	f0 := MustParseFloat(1234.5678)
 	if f0.Int() != 1234 {
 		t.Error("should be equal", f0.Int(), 1234)
 	}
@@ -452,43 +433,43 @@ func TestIntFrac(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	f0 := NewF(1234.5678)
+	f0 := MustParseFloat(1234.5678)
 	if f0.String() != "1234.5678" {
 		t.Error("should be equal", f0.String(), "1234.5678")
 	}
-	f0 = NewF(1234.0)
+	f0 = MustParseFloat(1234.0)
 	if f0.String() != "1234" {
 		t.Error("should be equal", f0.String(), "1234")
 	}
 }
 
 func TestStringN(t *testing.T) {
-	f0 := NewS("1.1")
+	f0 := MustParse("1.1")
 	s := f0.StringN(2)
 
 	if s != "1.10" {
 		t.Error("should be equal", s, "1.10")
 	}
-	f0 = NewS("1")
+	f0 = MustParse("1")
 	s = f0.StringN(2)
 
 	if s != "1.00" {
 		t.Error("should be equal", s, "1.00")
 	}
 
-	f0 = NewS("1.123")
+	f0 = MustParse("1.123")
 	s = f0.StringN(2)
 
 	if s != "1.12" {
 		t.Error("should be equal", s, "1.12")
 	}
-	f0 = NewS("1.123")
+	f0 = MustParse("1.123")
 	s = f0.StringN(2)
 
 	if s != "1.12" {
 		t.Error("should be equal", s, "1.12")
 	}
-	f0 = NewS("1.123")
+	f0 = MustParse("1.123")
 	s = f0.StringN(0)
 
 	if s != "1" {
@@ -497,7 +478,7 @@ func TestStringN(t *testing.T) {
 }
 
 func TestRound(t *testing.T) {
-	f0 := NewS("1.12345")
+	f0 := MustParse("1.12345")
 	f1 := f0.Round(2)
 
 	if f1.String() != "1.12" {
@@ -515,7 +496,7 @@ func TestRound(t *testing.T) {
 		t.Error("should be equal", f1, "1.1235")
 	}
 
-	f0 = NewS("-1.12345")
+	f0 = MustParse("-1.12345")
 	f1 = f0.Round(3)
 
 	if f1.String() != "NaN" {
@@ -531,7 +512,7 @@ func TestRound(t *testing.T) {
 func TestEncodeDecode(t *testing.T) {
 	b := &bytes.Buffer{}
 
-	f := NewS("12345.12345")
+	f := MustParse("12345.12345")
 
 	f.WriteTo(b)
 
@@ -548,74 +529,10 @@ func TestEncodeDecode(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	f1 := NewF(0)
+	f1 := MustParseFloat(0)
 	f1.UnmarshalBinary(data)
 
 	if !f.Equal(f1) {
 		t.Error("don't match", f, f0)
 	}
-}
-
-type JStruct struct {
-	F Decimal `json:"f"`
-}
-
-func TestJSON(t *testing.T) {
-	j := JStruct{}
-
-	f := NewS("1234567.1234567")
-	j.F = f
-
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-
-	err := enc.Encode(&j)
-	if err != nil {
-		t.Error(err)
-	}
-
-	j.F = Zero
-
-	dec := json.NewDecoder(&buf)
-
-	err = dec.Decode(&j)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !j.F.Equal(f) {
-		t.Error("don't match", j.F, f)
-	}
-}
-
-func TestJSON_NaN(t *testing.T) {
-	j := JStruct{}
-
-	f := NewS("NaN")
-	j.F = f
-
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-
-	err := enc.Encode(&j)
-	if err != nil {
-		t.Error(err)
-
-	}
-
-	j.F = Zero
-
-	dec := json.NewDecoder(&buf)
-
-	err = dec.Decode(&j)
-	if err != nil {
-		t.Error(err)
-
-	}
-
-	if !j.F.IsNaN() {
-		t.Error("did not decode NaN", j.F, f)
-
-	}
-
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/geseq/udecimal
 
 go 1.17
 
-require github.com/shopspring/decimal v1.3.1
+require (
+	github.com/shopspring/decimal v1.3.1
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
NaN's have inconsistent outputs on different operations and don't really serve a purpose. If NaN happens in an orderbook it's a panic worthy situation. Hence, replace with checks and panics where applicable